### PR TITLE
fix(Flutter): 'FingerprintSDK' cannot be constructed because it has no accessi…

### DIFF
--- a/xendit_cards_session/example/ios/Podfile.lock
+++ b/xendit_cards_session/example/ios/Podfile.lock
@@ -2,13 +2,19 @@ PODS:
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
-  - xendit_cards_session (0.0.1):
+  - xendit_cards_session (1.1.0):
     - Flutter
+    - XenditFingerprintSDK (= 1.0.1)
+  - XenditFingerprintSDK (1.0.1)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - xendit_cards_session (from `.symlinks/plugins/xendit_cards_session/ios`)
+
+SPEC REPOS:
+  trunk:
+    - XenditFingerprintSDK
 
 EXTERNAL SOURCES:
   Flutter:
@@ -21,7 +27,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
-  xendit_cards_session: 9510def8a2d1473be867771e84398fb91c728dad
+  xendit_cards_session: 1edca659fddc9138c5fd61c2973b0bb5a55b4008
+  XenditFingerprintSDK: 29410a2dcf467fe33d6e0167f590deae47c753ee
 
 PODFILE CHECKSUM: 8f3d15695469162b90aab66643ceac7b4b776d4b
 

--- a/xendit_cards_session/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/xendit_cards_session/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -54,6 +55,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/xendit_cards_session/ios/Classes/XenditCardsSessionPlugin.swift
+++ b/xendit_cards_session/ios/Classes/XenditCardsSessionPlugin.swift
@@ -36,7 +36,7 @@ public class XenditCardsSessionPlugin: NSObject, FlutterPlugin {
       // Initialize the fingerprint SDK if available
       #if canImport(XenditFingerprintSDK)
       do {
-        self.fingerprintSDK = FingerprintSDK()
+        self.fingerprintSDK = FingerprintSDK.shared
         try self.fingerprintSDK?.initSDK(apiKey: apiKey)
       } catch {
         self.fingerprintSDK = nil

--- a/xendit_cards_session/ios/xendit_cards_session.podspec
+++ b/xendit_cards_session/ios/xendit_cards_session.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'xendit_cards_session'
-  s.version          = '0.0.1'
+  s.version          = '1.1.0'
   s.summary          = 'A new Flutter plugin project.'
   s.description      = <<-DESC
 A new Flutter plugin project.
@@ -15,7 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'XenditFingerprintSDK'
+  s.dependency 'XenditFingerprintSDK', '1.0.1'
   
   s.platform = :ios, '12.0'
 


### PR DESCRIPTION
…ble initializers

This error happend when trying to run with Flutter in iOS device, and this commit fixes it by changing `FingerprintSDK()` -> `FingerprintSDK.shared` inside the `XenditCardsSessionPlugin.swift` file